### PR TITLE
Fixed vulnerable dependency. (lodash)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "lab-config",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lab-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Configuration service for the lab-di.",
   "main": "index.js",
   "scripts": {
@@ -37,7 +37,9 @@
   ],
   "author": "ifroz",
   "contributors": [
-    {"name": "Ádám Gólya"}
+    {
+      "name": "Ádám Gólya"
+    }
   ],
   "license": "ISC",
   "bugs": {
@@ -46,7 +48,7 @@
   "homepage": "https://github.com/lab-coop/lab-config#readme",
   "dependencies": {
     "config": "1.24.0",
-    "lodash": "4.17.2"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "cucumber": "1.3.1",


### PR DESCRIPTION
Fixed the vulnerable lodash by upgrading to a non-vulnerable version.
You may want the other dependencies upgraded as well just to clear _npm audit_.